### PR TITLE
Update top-level .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,17 @@
-# Files created by the pipeline, which we want to keep out of git
-# (or at least out of _this_ git repo).
+# Files created by workflows that we usually want to keep out of git
+auspice/
+builds/
 data/
 results/
-auspice/
-build/
+logs/
+benchmarks/
 
 # Sensitive environment variables
 environment*
+env.d/
 
-# Snakemake state dir
-/.snakemake
-
-# Local config overrides
-/config_local.yaml
+# Snakemake
+.snakemake/
 
 # For Python #
 ##############
@@ -39,3 +38,14 @@ environment*
 Icon?
 ehthumbs.db
 Thumbs.db
+*~
+
+# IDE generated files #
+######################
+.vscode/
+
+# nohup output
+nohup.out
+
+# cluster logs
+slurm-*


### PR DESCRIPTION
## Description of proposed changes
Replaced top-level .gitignore with .gitignore from [pathogen-repo-template](https://github.com/nextstrain/pathogen-repo-template/blob/cd1ef12987b71a1fd8dd73eafb8c8c4bd4e6d817/.gitignore) since this will be needed by both the add-ingest and add-phylogenetic PR's

## Related issue(s)

- https://github.com/nextstrain/measles/pull/10


## Checklist

- [ ] Checks pass

