### PR TITLE
ingest: Move intermediate file to `data` directory

### DIFF
--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -7,7 +7,7 @@ REQUIRED INPUTS:
 
 OUTPUTS:
 
-    metadata    = results/subset_metadata.tsv
+    metadata    = results/metadata.tsv
     sequences   = results/sequences.fasta
 
 """
@@ -61,7 +61,7 @@ rule curate:
         all_geolocation_rules="data/all-geolocation-rules.tsv",
         annotations=config["curate"]["annotations"],
     output:
-        metadata="results/all_metadata.tsv",
+        metadata="data/all_metadata.tsv",
         sequences="results/sequences.fasta",
     log:
         "logs/curate.txt",
@@ -118,7 +118,7 @@ rule curate:
 
 rule subset_metadata:
     input:
-        metadata="results/all_metadata.tsv",
+        metadata="data/all_metadata.tsv",
     output:
         subset_metadata="results/metadata.tsv",
     params:


### PR DESCRIPTION
## Description of proposed changes
Change the output directory for all_metadata.tsv from `results` to `data`
Follow up to [nextstrain/measles#10 (comment)](https://github.com/nextstrain/measles/pull/10#discussion_r1485642624)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
