### PR TITLE
Add nextstrain-automation build-configs to phylogenetic workflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # CHANGELOG
+* 2 April 2024: Add nextstrain-automation build-configs for deploying the final Auspice dataset of the phylogenetic workflow
 * 1 April 2024: Create a tree using the 450 nucleotides encoding the carboxyl-terminal 150 amino acids of the nucleoprotein (N450), which is highly represented on NCBI for measles. [PR #20](https://github.com/nextstrain/measles/pull/20)
 * 15 March 2024: Connect ingest and phylogenetic workflows to follow the pathogen-repo-guide by uploading ingest output to S3, downloading ingest output from S3 to phylogenetic directory, using "accession" column as the ID column, and using a color scheme that matches the new region name format. [PR #19](https://github.com/nextstrain/measles/pull/19)
 * 1 March 2024: Add phylogenetic directory to follow the pathogen-repo-guide, and update the CI workflow to match the new file structure. [PR #18](https://github.com/nextstrain/measles/pull/18)

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -47,7 +47,7 @@ Alternatively, you can run the build using the
 example data provided in this repository.  To run the build by copying the
 example sequences into the `data/` directory, use the following:
 
-    nextstrain build .  --configfile profiles/ci/profiles_config.yaml
+    nextstrain build .  --configfile build-configs/ci/config.yaml
 
 ### Deploying build
 

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -48,3 +48,17 @@ example data provided in this repository.  To run the build by copying the
 example sequences into the `data/` directory, use the following:
 
     nextstrain build .  --configfile profiles/ci/profiles_config.yaml
+
+### Deploying build
+
+To run the workflow and automatically deploy the build to nextstrain.org,
+you will need to have AWS credentials to run the following:
+
+```
+nextstrain build \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    . \
+        deploy_all \
+        --configfile build-configs/nextstrain-automation/config.yaml
+```

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -27,10 +27,10 @@ Once you've run the build, you can view the results with:
 
 ## Configuration
 
-Configuration takes place entirely with the `Snakefile`. This can be read
-top-to-bottom, each rule specifies its file inputs and output and also its
-parameters. There is little redirection and each rule should be able to be
-reasoned with on its own.
+Configuration for the workflow takes place entirely within the [defaults/config.yaml](defaults/config.yaml).
+The analysis pipeline is contained in [Snakefile](Snakefile) with included [rules](rules).
+Each rule specifies its file inputs and output and pulls its parameters from the config.
+There is little redirection and each rule should be able to be reasoned with on its own.
 
 ### Using GenBank data
 

--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,0 +1,4 @@
+custom_rules:
+  - build-configs/nextstrain-automation/deploy.smk
+
+deploy_url: "s3://nextstrain-data"

--- a/phylogenetic/build-configs/nextstrain-automation/deploy.smk
+++ b/phylogenetic/build-configs/nextstrain-automation/deploy.smk
@@ -1,0 +1,15 @@
+"""
+This part of the workflow handles automatic deployments of the measles build.
+Uploads the build defined as the default output of the workflow through
+the `all` rule from Snakefille
+"""
+
+rule deploy_all:
+    input: *rules.all.input
+    output: touch("results/deploy_all.done")
+    params:
+        deploy_url = config["deploy_url"]
+    shell:
+        """
+        nextstrain remote upload {params.deploy_url} {input}
+        """


### PR DESCRIPTION
## Description of proposed changes

Adds a custom config and rules for deploying the final Auspice dataset of the phylogenetic workflow.

Duplicates changes from https://github.com/nextstrain/zika/pull/51

## Related issue(s)

https://github.com/nextstrain/zika/pull/51
https://github.com/nextstrain/dengue/pull/37

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
