### PR TITLE
phylogenetic: Use inline root sequence

### DIFF
--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -17,8 +17,7 @@ rule export:
         auspice_config = lambda wildcard: "defaults/auspice_config.json" if wildcard.gene in ["genome"] else "defaults/auspice_config_N450.json"
 
     output:
-        auspice_json = "auspice/measles_{gene}.json",
-        root_sequence = "auspice/measles_{gene}_root-sequence.json"
+        auspice_json = "auspice/measles_{gene}.json"
     params:
         strain_id = config["strain_id_field"]
     shell:
@@ -30,7 +29,6 @@ rule export:
             --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} \
             --colors {input.colors} \
             --auspice-config {input.auspice_config} \
-            --include-root-sequence \
+            --include-root-sequence-inline \
             --output {output.auspice_json}
         """
-        


### PR DESCRIPTION
## Description of proposed changes

~Explicitly state that the root-sequence.json file is an expected output of the core phylogenetic workflow.~

~This also ensures that the Nextstrain automation rule `deploy_all` will include the root-sequence.json in the upload.~

Based on feedback from @jameshadfield in
https://github.com/nextstrain/zika/pull/56#issuecomment-2058060422

Looking at the existing dataset files on S3,
the 8 KiB root-sequence.json is pretty negligible when the main
Auspice JSON is only 163 KiB. Nextstrain datasets are limited by the
500MB memory cap in Chrome,¹ so we'd be fine adding the
root sequence inline.

This ensures that our uploads will include the root sequence so that
they don't get out-of-sync with the main Auspice JSON.

¹ https://github.com/nextstrain/auspice/issues/1622

## Related issue(s)

Follow up to https://github.com/nextstrain/measles/pull/21
Similar to https://github.com/nextstrain/zika/pull/56

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
