### PR TITLE
Remove time information from Nextclade dataset tree

### DIFF
--- a/nextclade/defaults/auspice_config.json
+++ b/nextclade/defaults/auspice_config.json
@@ -12,11 +12,6 @@
       "type": "categorical"
     },
     {
-      "key": "num_date",
-      "title": "Date",
-      "type": "continuous"
-    },
-    {
       "key": "clade_membership",
       "title": "MeV Genotype (Nextstrain)",
       "type": "categorical"

--- a/nextclade/rules/construct_phylogeny.smk
+++ b/nextclade/rules/construct_phylogeny.smk
@@ -31,7 +31,6 @@ rule refine:
         metadata = "data/metadata.tsv"
     output:
         tree = "results/tree.nwk",
-        node_data = "results/branch_lengths.json"
     params:
         coalescent = config["refine"]["coalescent"],
         date_inference = config["refine"]["date_inference"],
@@ -45,7 +44,6 @@ rule refine:
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
             --output-tree {output.tree} \
-            --output-node-data {output.node_data} \
             --timetree \
             --coalescent {params.coalescent} \
             --date-confidence \

--- a/nextclade/rules/export.smk
+++ b/nextclade/rules/export.smk
@@ -10,7 +10,6 @@ rule export:
     input:
         tree = "results/tree.nwk",
         metadata = "data/metadata.tsv",
-        branch_lengths = "results/branch_lengths.json",
         clades = "results/clades.json",
         nt_muts = "results/nt_muts.json",
         aa_muts = "results/aa_muts.json",
@@ -27,7 +26,7 @@ rule export:
             --tree {input.tree} \
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} \
+            --node-data {input.nt_muts} {input.aa_muts} {input.clades} \
             --colors {input.colors} \
             --metadata-columns {params.metadata_columns} \
             --auspice-config {input.auspice_config} \


### PR DESCRIPTION
## Description of proposed changes

This PR removes the commands that add time information to the Nextclade dataset tree, since Nextclade doesn't use this information. This change was recommended [here](https://github.com/nextstrain/nextclade_data/pull/202#issuecomment-2130148472)

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)
https://github.com/nextstrain/nextclade_data/pull/202#issuecomment-2130148472

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
