### PR TITLE
Fixup: Remove time information from Nextclade dataset tree

### DIFF
--- a/nextclade/defaults/auspice_config.json
+++ b/nextclade/defaults/auspice_config.json
@@ -12,6 +12,11 @@
       "type": "categorical"
     },
     {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
       "key": "clade_membership",
       "title": "MeV Genotype (Nextstrain)",
       "type": "categorical"

--- a/nextclade/defaults/auspice_config.json
+++ b/nextclade/defaults/auspice_config.json
@@ -12,11 +12,6 @@
       "type": "categorical"
     },
     {
-      "key": "num_date",
-      "title": "Date",
-      "type": "continuous"
-    },
-    {
       "key": "clade_membership",
       "title": "MeV Genotype (Nextstrain)",
       "type": "categorical"

--- a/nextclade/rules/annotate_phylogeny.smk
+++ b/nextclade/rules/annotate_phylogeny.smk
@@ -58,3 +58,17 @@ rule clades:
             --clades {input.clade_defs} \
             --output {output.clades}
         """
+
+rule timeout:
+    input: "results/branch_lengths.json"
+    output: "results/branch_lengths_div_only.json"
+    run:
+        import json
+        with open(input[0], 'r') as fh:
+            data = json.load(fh)        
+        new_nodes = {}
+        for name, attrs in data['nodes'].items():
+            new_nodes[name] = {'mutation_length': attrs.get('mutation_length')}
+        data['nodes'] = new_nodes
+        with open(output[0], 'w') as fh:
+            json.dump(data, fh, indent=2)

--- a/nextclade/rules/construct_phylogeny.smk
+++ b/nextclade/rules/construct_phylogeny.smk
@@ -31,6 +31,7 @@ rule refine:
         metadata = "data/metadata.tsv"
     output:
         tree = "results/tree.nwk",
+        node_data = "results/branch_lengths.json"
     params:
         coalescent = config["refine"]["coalescent"],
         date_inference = config["refine"]["date_inference"],
@@ -44,6 +45,7 @@ rule refine:
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
             --output-tree {output.tree} \
+            --output-node-data {output.node_data} \
             --timetree \
             --coalescent {params.coalescent} \
             --date-confidence \

--- a/nextclade/rules/export.smk
+++ b/nextclade/rules/export.smk
@@ -10,6 +10,7 @@ rule export:
     input:
         tree = "results/tree.nwk",
         metadata = "data/metadata.tsv",
+        branch_lengths = "results/branch_lengths.json",
         clades = "results/clades.json",
         nt_muts = "results/nt_muts.json",
         aa_muts = "results/aa_muts.json",
@@ -26,7 +27,7 @@ rule export:
             --tree {input.tree} \
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
-            --node-data {input.nt_muts} {input.aa_muts} {input.clades} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} \
             --colors {input.colors} \
             --metadata-columns {params.metadata_columns} \
             --auspice-config {input.auspice_config} \

--- a/nextclade/rules/export.smk
+++ b/nextclade/rules/export.smk
@@ -10,7 +10,7 @@ rule export:
     input:
         tree = "results/tree.nwk",
         metadata = "data/metadata.tsv",
-        branch_lengths = "results/branch_lengths.json",
+        branch_lengths = "results/branch_lengths_div_only.json",
         clades = "results/clades.json",
         nt_muts = "results/nt_muts.json",
         aa_muts = "results/aa_muts.json",


### PR DESCRIPTION
## Description of proposed changes

The goal of this PR is to remove time information from the Nextclade dataset tree, since Nextclade doesn't use this information. This change was originally recommended in https://github.com/nextstrain/nextclade_data/pull/202#issuecomment-2130148472

[Initial efforts to accomplish this goal](https://github.com/nextstrain/measles/pull/33) involved exporting the Nextclade tree using branch lengths in tree.nwk (rather than in branch_lengths.json), under the assumption that these were divergence branch lengths, but actually they are time branch lengths. Therefore we need a different approach to remove time information.

This PR first reverts the changes from the initial approach, and then removes all node attributes except divergence branch lengths (`mutation_length` attribute) from branch_lengths.json before exporting the Nextclade tree.


## Related issue(s)

https://github.com/nextstrain/nextclade_data/pull/202#issuecomment-2130148472
https://github.com/nextstrain/measles/pull/33

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
