### PR TITLE
Switch AWS credentials from a long-lived IAM user to short-lived role sessions

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -55,8 +55,6 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.ingest_image }}
       run: |
         nextstrain build \
-          --env AWS_ACCESS_KEY_ID \
-          --env AWS_SECRET_ACCESS_KEY \
           ingest \
             upload_all \
             --configfile build-configs/nextstrain-automation/config.yaml
@@ -128,8 +126,6 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.phylogenetic_image }}
       run: |
         nextstrain build \
-          --env AWS_ACCESS_KEY_ID \
-          --env AWS_SECRET_ACCESS_KEY \
           phylogenetic \
             deploy_all \
             --configfile build-configs/nextstrain-automation/config.yaml


### PR DESCRIPTION
I'll be removing the corresponding repository secrets and _that_ will actually effect the switch; this commit merely cleans up the unnecessary passing of --env.

Related-to: <https://github.com/nextstrain/private/issues/110>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
