### PR TITLE
Switch CI to pathogen-repo-ci workflow 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,28 +1,12 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  pathogen-ci:
-    strategy:
-      matrix:
-        runtime: [docker, conda]
-    permissions:
-      id-token: write
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
-    secrets: inherit
-    with:
-      runtime: ${{ matrix.runtime }}
-      run: |
-        nextstrain build \
-          phylogenetic \
-          --configfile build-configs/ci/config.yaml
-      artifact-name: output-${{ matrix.runtime }}
-      artifact-paths: |
-        phylogenetic/auspice/
-        phylogenetic/results/
-        phylogenetic/benchmarks/
-        phylogenetic/logs/
-        phylogenetic/.snakemake/log/
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master

--- a/ingest/build-configs/ci/config.yaml
+++ b/ingest/build-configs/ci/config.yaml
@@ -1,0 +1,6 @@
+# TODO: If the ingest workflow ever runs too long, we should figure out a way
+# to subset the ingest data. Currently, the CI just runs the default ingest workflow.
+
+# Snakemake requires at least one top level key in a config file, so including
+# a bogus key here that should not be used anywhere in the Snakemake workflow
+bogus_ci_config: "bogus_ci_config"


### PR DESCRIPTION
## Description of proposed changes

See https://github.com/nextstrain/.github/issues/94 for context

The ingest workflow runs in <2 minutes so I figured it'd be nice to add as an additional check in the GH Action CI workflow.
Copied [change made in zika](https://github.com/nextstrain/zika/commit/44f27a5670e391b4a5df93ba56d08e2d99fa415c). 


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
