### PR TITLE
feat(ci): Use cached ncbi dataset package to isolate tests

### DIFF
--- a/ingest/build-configs/ci/config.yaml
+++ b/ingest/build-configs/ci/config.yaml
@@ -1,5 +1,5 @@
-# TODO: If the ingest workflow ever runs too long, we should figure out a way
-# to subset the ingest data. Currently, the CI just runs the default ingest workflow.
+# Use cached ncbi datasets package to speed up tests and isolate from ncbi servers
+mock_fetch: true
 
 # Snakemake requires at least one top level key in a config file, so including
 # a bogus key here that should not be used anywhere in the Snakemake workflow

--- a/ingest/build-configs/ci/config.yaml
+++ b/ingest/build-configs/ci/config.yaml
@@ -1,5 +1,5 @@
-# Use cached ncbi datasets package to speed up tests and isolate from ncbi servers
-mock_fetch: true
+custom_rules:
+  - "build-configs/ci/copy_example_data.smk"
 
 # Snakemake requires at least one top level key in a config file, so including
 # a bogus key here that should not be used anywhere in the Snakemake workflow

--- a/ingest/build-configs/ci/copy_example_data.smk
+++ b/ingest/build-configs/ci/copy_example_data.smk
@@ -1,0 +1,14 @@
+rule copy_example_data:
+    input:
+        ncbi_dataset="example_data/ncbi_dataset.zip"
+    output:
+        ncbi_dataset=temp("data/ncbi_dataset.zip")
+    shell:
+        """
+        cp -f {input.ncbi_dataset} {output.ncbi_dataset}
+        """
+
+# Add a Snakemake ruleorder directive here if you need to resolve ambiguous rules
+# that have the same output as the copy_example_data rule.
+
+ruleorder: copy_example_data > fetch_ncbi_dataset_package

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -45,18 +45,9 @@ rule fetch_ncbi_dataset_package:
         """
 
 
-def get_ncbi_dataset_package_path():
-    """
-    Use cached data package in ci to isolate from ncbi server
-    """
-    if config.get("mock_fetch", False):
-        return "test_data/ncbi_dataset.zip"
-    return "data/ncbi_dataset.zip"
-
-
 rule extract_ncbi_dataset_sequences:
     input:
-        dataset_package=get_ncbi_dataset_package_path(),
+        dataset_package="data/ncbi_dataset.zip",
     output:
         ncbi_dataset_sequences=temp("data/ncbi_dataset_sequences.fasta"),
     benchmark:
@@ -70,7 +61,7 @@ rule extract_ncbi_dataset_sequences:
 
 rule format_ncbi_dataset_report:
     input:
-        dataset_package=get_ncbi_dataset_package_path(),
+        dataset_package="data/ncbi_dataset.zip",
     output:
         ncbi_dataset_tsv=temp("data/ncbi_dataset_report.tsv"),
     params:
@@ -116,4 +107,3 @@ rule format_ncbi_datasets_ndjson:
             --duplicate-reporting warn \
             2> {log} > {output.ndjson}
         """
-

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -45,9 +45,18 @@ rule fetch_ncbi_dataset_package:
         """
 
 
+def get_ncbi_dataset_package_path():
+    """
+    Use cached data package in ci to isolate from ncbi server
+    """
+    if config.get("mock_fetch", False):
+        return "test_data/ncbi_dataset.zip"
+    return "data/ncbi_dataset.zip"
+
+
 rule extract_ncbi_dataset_sequences:
     input:
-        dataset_package="data/ncbi_dataset.zip",
+        dataset_package=get_ncbi_dataset_package_path(),
     output:
         ncbi_dataset_sequences=temp("data/ncbi_dataset_sequences.fasta"),
     benchmark:
@@ -61,7 +70,7 @@ rule extract_ncbi_dataset_sequences:
 
 rule format_ncbi_dataset_report:
     input:
-        dataset_package="data/ncbi_dataset.zip",
+        dataset_package=get_ncbi_dataset_package_path(),
     output:
         ncbi_dataset_tsv=temp("data/ncbi_dataset_report.tsv"),
     params:


### PR DESCRIPTION
Resolves #46, see that issue for motivation

The zip file is 8MB which is ok. If we wanted to use less space, we could turn the package into a `.tar.zst` which uses only `1.4MB`.

The pattern of not calling datasets in CI could be copied to other repos and/or the template if it's something we feel is useful.

- [x] Checks pass
