### PR TITLE
feat(ingest): store translations as `.tar.zst` instead of `.zip`

### DIFF
--- a/ingest/build-configs/nextstrain-automation/config.yaml
+++ b/ingest/build-configs/nextstrain-automation/config.yaml
@@ -21,4 +21,4 @@ files_to_upload:
   sequences.fasta.zst: results/sequences.fasta
   nextclade.tsv.zst: results/nextclade.tsv
   alignment.fasta.zst: results/alignment.fasta
-  translations.zip: results/translations.zip
+  translations.tar.zst: results/translations.tar

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -30,7 +30,7 @@ rule run_nextclade:
     output:
         nextclade="results/nextclade.tsv",
         alignment="results/alignment.fasta",
-        translations="results/translations.zip",
+        translations="results/translations.tar",
     params:
         translations=lambda w: "results/translations/{cds}.fasta",
     shell:
@@ -42,7 +42,7 @@ rule run_nextclade:
             --output-fasta {output.alignment} \
             --output-translations {params.translations}
 
-        zip -rj {output.translations} results/translations
+        tar caf results/translations.tar results/translations
         """
 
 

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -21,7 +21,7 @@ We curate sequence data and metadata from NCBI as starting point for our analyse
 Pairwise alignments with [Nextclade](https://docs.nextstrain.org/projects/nextclade/en/stable) against the N450 region of [reference sequence Ichinose-B95a](https://www.ncbi.nlm.nih.gov/nuccore/NC_001498.1), clade assignments, and N450 region quality control metrics and translations are available at
 - [data.nextstrain.org/files/workflows/measles/alignment.fasta.zst](https://data.nextstrain.org/files/workflows/measles/alignment.fasta.zst)
 - [data.nextstrain.org/files/workflows/measles/nextclade.tsv.zst](https://data.nextstrain.org/files/workflows/measles/nextclade.tsv.zst)
-- [data.nextstrain.org/files/workflows/measles/translations.zip](https://data.nextstrain.org/files/workflows/measles/translations.zip)
+- [data.nextstrain.org/files/workflows/measles/translations.tar.zst](https://data.nextstrain.org/files/workflows/measles/translations.tar.zst)
 
 ---
 


### PR DESCRIPTION
In general, we should use zst over zip/gzip/xz due to faster (de)compression and also often higher compression ratios (for longer sequences).

While the default compression with .tar.zst is slightly less dense than .zip, this is tunable and with e.g. -10 we get smaller outputs

My suggestion is to use .tar.zst for a uniform API across nextstrain ingest outputs - in this case here it doesn't matter as it's just 100kB anyways.

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
