### PR TITLE
chore(dev): set default profile for convenience

### DIFF
--- a/ingest/profiles/default/config.yaml
+++ b/ingest/profiles/default/config.yaml
@@ -1,0 +1,2 @@
+rerun-incomplete: true
+printshellcmds: true


### PR DESCRIPTION
It's annoying to have to type `--ri` all the time, and have shell cmds not printed in dry runs

Setting default cmd line flags like this is a dev convenience

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
