### PR TITLE
Add `division` to allowed geo-resolutions

### DIFF
--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -38,14 +38,20 @@
       "type": "categorical"
     },
     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
       "key": "genotype_ncbi",
       "title": "MeV Genotype (GenBank metadata)",
       "type": "categorical"
     }
   ],
   "geo_resolutions": [
+    "region",
     "country",
-    "region"
+    "division"
   ],
   "display_defaults": {
     "map_triplicate": true,

--- a/phylogenetic/defaults/auspice_config_N450.json
+++ b/phylogenetic/defaults/auspice_config_N450.json
@@ -38,6 +38,11 @@
       "type": "categorical"
     },
     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
       "key": "genotype_ncbi",
       "title": "MeV Genotype (GenBank metadata)",
       "type": "categorical"
@@ -49,8 +54,9 @@
     }
   ],
   "geo_resolutions": [
+    "region",
     "country",
-    "region"
+    "division"
   ],
   "display_defaults": {
     "map_triplicate": true,


### PR DESCRIPTION
## Description of proposed changes

Add coloring and geo-resolution for `division` so that it can be viewed on the tree.

Here is a screenshot of the output tree:

<img width="1660" alt="image" src="https://github.com/user-attachments/assets/cbd12c70-e93d-4e99-b42b-fda957f5b52d" />


## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
