### PR TITLE
Exclude reference in filter step

### DIFF
--- a/phylogenetic/defaults/dropped_strains.txt
+++ b/phylogenetic/defaults/dropped_strains.txt
@@ -1,2 +1,3 @@
+NC_001498 # reference
 HM562901 # temara.MOR/24.03
 HM562900 # Mvs/Toulon.FRA/08.07


### PR DESCRIPTION
## Description of proposed changes

This prevents stochastic errors from augur align that would occur when the input --sequences contained the reference sequence due to random sampling.

## Related issue(s)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
