### PR TITLE
Consolidate filepath resolution

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -1,10 +1,14 @@
 strain_id_field: "accession"
 files:
-    reference: "measles_reference_{gene}.gb"
-    reference_fasta: "measles_reference_{gene}.fasta"
     colors: "colors.tsv"
-    auspice_config: "auspice_config_{gene}.json"
     description: "description.md"
+    genome:
+        reference: "measles_reference_genome.gb"
+        auspice_config: "auspice_config_genome.json"
+    N450:
+        reference: "measles_reference_N450.gb"
+        reference_fasta: "measles_reference_N450.fasta"
+        auspice_config: "auspice_config_N450.json"
 align_and_extract_N450:
     min_length: 400
 subsample:

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -28,7 +28,7 @@ rule translate:
     input:
         tree = "results/{gene}/tree.nwk",
         node_data = "results/{gene}/nt_muts.json",
-        reference = resolve_config_path(config["files"]["reference"])
+        reference = lambda w: config["files"][w.gene]["reference"]
     output:
         node_data = "results/{gene}/aa_muts.json"
     shell:

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -16,6 +16,11 @@ RUN_CONFIG = f"results/run_config.yaml"
 
 def main():
     resolve_filepaths([
+        ("files", "colors"),
+        ("files", "description"),
+        ("files", "*", "reference"),
+        ("files", "*", "reference_fasta"),
+        ("files", "*", "auspice_config"),
         ("subsample", "*", "samples", "*", "include"),
         ("subsample", "*", "samples", "*", "exclude"),
         ("subsample", "*", "samples", "*", "group_by_weights"),

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -13,9 +13,9 @@ rule export:
         branch_lengths = "results/{gene}/branch_lengths.json",
         nt_muts = "results/{gene}/nt_muts.json",
         aa_muts = "results/{gene}/aa_muts.json",
-        colors = resolve_config_path(config["files"]["colors"]),
-        auspice_config = resolve_config_path(config["files"]["auspice_config"]),
-        description=resolve_config_path(config["files"]["description"])
+        colors = config["files"]["colors"],
+        auspice_config = lambda w: config["files"][w.gene]["auspice_config"],
+        description = config["files"]["description"]
     output:
         auspice_json = "auspice/measles_{gene}.json"
     params:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -66,7 +66,7 @@ rule align:
     """
     input:
         sequences = "results/genome/filtered.fasta",
-        reference = resolve_config_path(config["files"]["reference"])({"gene": "genome"})
+        reference = config["files"]["genome"]["reference"]
     output:
         alignment = "results/genome/aligned.fasta"
     shell:

--- a/phylogenetic/rules/prepare_sequences_N450.smk
+++ b/phylogenetic/rules/prepare_sequences_N450.smk
@@ -7,7 +7,7 @@ See Augur's usage docs for these commands for more details.
 rule align_and_extract_N450:
     input:
         sequences = "data/sequences.fasta",
-        reference = resolve_config_path(config["files"]["reference_fasta"])({"gene":"N450"})
+        reference = config["files"]["N450"]["reference_fasta"]
     output:
         sequences = "results/N450/sequences.fasta"
     params:


### PR DESCRIPTION
## Description of proposed changes

Filepaths in the config are either resolved within rules or at the start of the workflow.

Resolve all filepaths at the start of the workflow to keep things consolidated.

The current implementation does not allow for string placeholders in filepaths, so the config has been adjusted to replace those with expanded versions.

## Related issue(s)

https://github.com/nextstrain/public/issues/23

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog
- [ ] Apply to ingest and nextclade workflows too?

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
