### PR TITLE
Build specs to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 
 ## 2025
-
+* 30 September 2025: The `'gene'` wildcard was renamed as `'build'`, and is now a config key rather than a declaration in the `phylogenetic` snakefile.
 * 29 September 2025: Restored support for `nextstrain run`, which was broken in the switch the augur subsample. [#73][]
 * 26 September 2025: Updated workflow compatibility declaration in `nextstrain-pathogen.yaml`.
   **This requires Nextstrain CLI >=10.3.0** to setup and update the pathogen without error messages.

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -9,6 +9,9 @@ include: "rules/config.smk"
 
 builds = config['builds']
 
+wildcard_constraints:
+    build = "genome|N450"
+
 rule all:
     input:
         auspice_json = expand("auspice/measles_{build}.json", build=builds),

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -1,5 +1,3 @@
-genes = ['N450', 'genome']
-
 include: "../shared/vendored/snakemake/config.smk"
 
 configfile: os.path.join(workflow.basedir, "defaults/config.yaml")
@@ -9,10 +7,12 @@ if os.path.exists("config.yaml"):
 
 include: "rules/config.smk"
 
+builds = config['builds']
+
 rule all:
     input:
-        auspice_json = expand("auspice/measles_{gene}.json", gene=genes),
-        tip_frequencies_json = expand("auspice/measles_{gene}_tip-frequencies.json", gene=genes)
+        auspice_json = expand("auspice/measles_{build}.json", build=builds),
+        tip_frequencies_json = expand("auspice/measles_{build}_tip-frequencies.json", build=builds)
 
 include: "rules/prepare_sequences.smk"
 include: "rules/prepare_sequences_N450.smk"

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -1,9 +1,10 @@
+builds: ['genome', 'N450']
 strain_id_field: "accession"
 files:
-    reference: "measles_reference_{gene}.gb"
-    reference_fasta: "measles_reference_{gene}.fasta"
+    reference: "measles_reference_{build}.gb"
+    reference_fasta: "measles_reference_{build}.fasta"
     colors: "colors.tsv"
-    auspice_config: "auspice_config_{gene}.json"
+    auspice_config: "auspice_config_{build}.json"
     description: "description.md"
 align_and_extract_N450:
     min_length: 400

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -8,10 +8,10 @@ See Augur's usage docs for these commands for more details.
 rule ancestral:
     """Reconstructing ancestral sequences and mutations"""
     input:
-        tree = "results/{gene}/tree.nwk",
-        alignment = "results/{gene}/aligned.fasta"
+        tree = "results/{build}/tree.nwk",
+        alignment = "results/{build}/aligned.fasta"
     output:
-        node_data = "results/{gene}/nt_muts.json"
+        node_data = "results/{build}/nt_muts.json"
     params:
         inference = config["ancestral"]["inference"]
     shell:
@@ -26,11 +26,11 @@ rule ancestral:
 rule translate:
     """Translating amino acid sequences"""
     input:
-        tree = "results/{gene}/tree.nwk",
-        node_data = "results/{gene}/nt_muts.json",
+        tree = "results/{build}/tree.nwk",
+        node_data = "results/{build}/nt_muts.json",
         reference = resolve_config_path(config["files"]["reference"])
     output:
-        node_data = "results/{gene}/aa_muts.json"
+        node_data = "results/{build}/aa_muts.json"
     shell:
         """
         augur translate \

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -7,9 +7,9 @@ See Augur's usage docs for these commands for more details.
 rule tree:
     """Building tree"""
     input:
-        alignment = "results/{gene}/aligned.fasta"
+        alignment = "results/{build}/aligned.fasta"
     output:
-        tree = "results/{gene}/tree_raw.nwk"
+        tree = "results/{build}/tree_raw.nwk"
     shell:
         """
         augur tree \
@@ -26,12 +26,12 @@ rule refine:
       - filter tips more than {params.clock_filter_iqd} IQDs from clock expectation
     """
     input:
-        tree = "results/{gene}/tree_raw.nwk",
-        alignment = "results/{gene}/aligned.fasta",
+        tree = "results/{build}/tree_raw.nwk",
+        alignment = "results/{build}/aligned.fasta",
         metadata = "data/metadata.tsv"
     output:
-        tree = "results/{gene}/tree.nwk",
-        node_data = "results/{gene}/branch_lengths.json"
+        tree = "results/{build}/tree.nwk",
+        node_data = "results/{build}/branch_lengths.json"
     params:
         coalescent = config["refine"]["coalescent"],
         date_inference = config["refine"]["date_inference"],

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -1,5 +1,5 @@
 """
-This part of the workflow collects the phylogenetic tree and annotations to
+This part of the workflow collects the phylobuildtic tree and annotations to
 export a Nextstrain dataset.
 
 See Augur's usage docs for these commands for more details.
@@ -8,16 +8,16 @@ See Augur's usage docs for these commands for more details.
 rule export:
     """Exporting data files for for auspice"""
     input:
-        tree = "results/{gene}/tree.nwk",
+        tree = "results/{build}/tree.nwk",
         metadata = "data/metadata.tsv",
-        branch_lengths = "results/{gene}/branch_lengths.json",
-        nt_muts = "results/{gene}/nt_muts.json",
-        aa_muts = "results/{gene}/aa_muts.json",
+        branch_lengths = "results/{build}/branch_lengths.json",
+        nt_muts = "results/{build}/nt_muts.json",
+        aa_muts = "results/{build}/aa_muts.json",
         colors = resolve_config_path(config["files"]["colors"]),
         auspice_config = resolve_config_path(config["files"]["auspice_config"]),
         description=resolve_config_path(config["files"]["description"])
     output:
-        auspice_json = "auspice/measles_{gene}.json"
+        auspice_json = "auspice/measles_{build}.json"
     params:
         strain_id = config["strain_id_field"],
         metadata_columns = config["export"]["metadata_columns"]
@@ -41,7 +41,7 @@ rule tip_frequencies:
     Estimating KDE frequencies for tips
     """
     input:
-        tree = "results/{gene}/tree.nwk",
+        tree = "results/{build}/tree.nwk",
         metadata = "data/metadata.tsv"
     params:
         strain_id = config["strain_id_field"],
@@ -50,7 +50,7 @@ rule tip_frequencies:
         narrow_bandwidth = config["tip_frequencies"]["narrow_bandwidth"],
         wide_bandwidth = config["tip_frequencies"]["wide_bandwidth"]
     output:
-        tip_freq = "auspice/measles_{gene}_tip-frequencies.json"
+        tip_freq = "auspice/measles_{build}_tip-frequencies.json"
     shell:
         """
         augur frequencies \

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -66,7 +66,7 @@ rule align:
     """
     input:
         sequences = "results/genome/filtered.fasta",
-        reference = resolve_config_path(config["files"]["reference"])({"gene": "genome"})
+        reference = resolve_config_path(config["files"]["reference"])({"build": "genome"})
     output:
         alignment = "results/genome/aligned.fasta"
     shell:

--- a/phylogenetic/rules/prepare_sequences_N450.smk
+++ b/phylogenetic/rules/prepare_sequences_N450.smk
@@ -7,7 +7,7 @@ See Augur's usage docs for these commands for more details.
 rule align_and_extract_N450:
     input:
         sequences = "data/sequences.fasta",
-        reference = resolve_config_path(config["files"]["reference_fasta"])({"gene":"N450"})
+        reference = resolve_config_path(config["files"]["reference_fasta"])({"build":"N450"})
     output:
         sequences = "results/N450/sequences.fasta"
     params:


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Add some flexibility to build designations (genome and N450)
Currently, the desired build (N450 and genome) is/are specified by the `'gene'` wildcard in the main `snakefile` under `phylogenetic`. Both .json files are produced by default.

This PR renames `'gene'` wildcard to `'build'` for consistency with other Nextstrain pathogens, and moves the wildcard definition to the config.yaml for ease of customization.

I'm submitting this as a draft for a few reasons:
- ~~I'm not sure, with how this is executed, if it will be possible to override the wildcard definition with another key in a custom config.yaml.~~ Testing with a custom config file (key with same name) seems to work without issues - confirmed in both run_config.yaml as well as build success.
- Will other config keys need to be made optional?

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

With these changes, I confirmed that both builds complete after changing all of the references throughout the phylogenetic workflows with all combinations of wildcard values ('N450', 'genome', and both).

- [X] Checks pass
- [X] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
