### PR TITLE
Consolidate filepath resolution (without changing config)

### DIFF
--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -28,7 +28,7 @@ rule translate:
     input:
         tree = "results/{gene}/tree.nwk",
         node_data = "results/{gene}/nt_muts.json",
-        reference = resolve_config_path(config["files"]["reference"])
+        reference = lambda w: processed_config["files"][w.gene]["reference"]
     output:
         node_data = "results/{gene}/aa_muts.json"
     shell:

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -3,13 +3,46 @@ This part of the workflow deals with configuration.
 
 OUTPUTS:
 
-    results/run_config.yaml
+    results/config_raw.yaml
+    results/config_processed.yaml
 """
+from copy import deepcopy
+
+# Dump the unmodified config to a YAML file.
+# This is useful for debugging the outcome of Snakemake's config merge (which
+# would've already happened by this point) and custom config processing (which
+# is about to happen).
+write_config(config, "results/config_raw.yaml")
+
+# Copy the config into a new variable, to be modified. We could modify 'config'
+# in-place, but the new name highlights its modified state.
+processed_config = deepcopy(config)
+
+# This is similar to wildcards functionality in Snakemake.
+# FIXME: builds, from config
+for gene in ['genome', 'N450']:
+    processed_config["files"][gene] = dict()
+    processed_config["files"][gene]["reference"] = processed_config["files"]["reference"].format(gene=gene)
+    processed_config["files"][gene]["auspice_config"] = processed_config["files"]["auspice_config"].format(gene=gene)
+
+# Note: this is not in the loop because there is no file for gene=genome.
+processed_config["files"]["N450"]["reference_fasta"] = processed_config["files"]["reference_fasta"].format(gene=gene)
+
+# Remove config keys that have been replaced above.
+del processed_config["files"]["reference"]
+del processed_config["files"]["reference_fasta"]
+del processed_config["files"]["auspice_config"]
 
 # NOTE: The order is important. Filepaths must be resolved before config is
 # written, otherwise augur subsample will not work.
 
-resolve_filepaths([
+# Resolve filepaths in the modified config variable.
+resolve_filepaths(processed_config, [
+    ("files", "colors"),
+    ("files", "description"),
+    ("files", "*", "reference"),
+    ("files", "*", "reference_fasta"),
+    ("files", "*", "auspice_config"),
     ("subsample", "*", "samples", "*", "include"),
     ("subsample", "*", "samples", "*", "exclude"),
     ("subsample", "*", "samples", "*", "group_by_weights"),
@@ -18,4 +51,5 @@ resolve_filepaths([
     ("custom_subsample", "*", "samples", "*", "group_by_weights"),
 ])
 
-write_config("results/run_config.yaml")
+# Write the modified config to a file. This will be used by augur subsample.
+write_config(processed_config, "results/config_processed.yaml")

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -13,9 +13,9 @@ rule export:
         branch_lengths = "results/{gene}/branch_lengths.json",
         nt_muts = "results/{gene}/nt_muts.json",
         aa_muts = "results/{gene}/aa_muts.json",
-        colors = resolve_config_path(config["files"]["colors"]),
-        auspice_config = resolve_config_path(config["files"]["auspice_config"]),
-        description=resolve_config_path(config["files"]["description"])
+        colors = processed_config["files"]["colors"],
+        auspice_config = lambda w: processed_config["files"][w.gene]["auspice_config"],
+        description = processed_config["files"]["description"]
     output:
         auspice_json = "auspice/measles_{gene}.json"
     params:

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -40,7 +40,7 @@ rule filter:
       - minimum genome length of {params.min_length}
     """
     input:
-        config = "results/run_config.yaml",
+        config = "results/config_processed.yaml",
         sequences = "data/sequences.fasta",
         metadata = "data/metadata.tsv"
     output:
@@ -66,7 +66,7 @@ rule align:
     """
     input:
         sequences = "results/genome/filtered.fasta",
-        reference = resolve_config_path(config["files"]["reference"])({"gene": "genome"})
+        reference = processed_config["files"]["genome"]["reference"]
     output:
         alignment = "results/genome/aligned.fasta"
     shell:

--- a/phylogenetic/rules/prepare_sequences_N450.smk
+++ b/phylogenetic/rules/prepare_sequences_N450.smk
@@ -7,7 +7,7 @@ See Augur's usage docs for these commands for more details.
 rule align_and_extract_N450:
     input:
         sequences = "data/sequences.fasta",
-        reference = resolve_config_path(config["files"]["reference_fasta"])({"gene":"N450"})
+        reference = processed_config["files"]["N450"]["reference_fasta"]
     output:
         sequences = "results/N450/sequences.fasta"
     params:
@@ -33,7 +33,7 @@ rule filter_N450:
       - excluding strains with missing region, country or date metadata
     """
     input:
-        config = "results/run_config.yaml",
+        config = "results/config_processed.yaml",
         sequences = "results/N450/sequences.fasta",
         metadata = "data/metadata.tsv"
     output:

--- a/shared/vendored/snakemake/config.smk
+++ b/shared/vendored/snakemake/config.smk
@@ -6,6 +6,7 @@ import os
 import sys
 import yaml
 from collections.abc import Callable
+from copy import deepcopy
 from snakemake.io import Wildcards
 from typing import Optional
 from textwrap import dedent, indent
@@ -15,7 +16,7 @@ class InvalidConfigError(Exception):
     pass
 
 
-def resolve_filepaths(filepaths):
+def resolve_filepaths(config, filepaths):
     """
     Update filepaths in-place by passing them through resolve_config_path().
 
@@ -23,7 +24,6 @@ def resolve_filepaths(filepaths):
     Use "*" as a a key-expansion placeholder: it means "iterate over all keys at
     this level".
     """
-    global config
 
     for keys in filepaths:
         _traverse(config, keys, traversed_keys=[])
@@ -147,12 +147,10 @@ def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callab
     return _resolve_config_path
 
 
-def write_config(path):
+def write_config(config, path):
     """
     Write Snakemake's 'config' variable to a file.
     """
-    global config
-
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
     with open(path, 'w') as f:


### PR DESCRIPTION
> [!NOTE]
> This requires changes to the shared config code which should be added upstream first.

## Description of proposed changes

Filepaths in the config are either resolved within rules or at the start of the workflow. Resolve all filepaths at the start of the workflow to keep things consolidated.

This solidifies the idea of processing config at Snakemake startup instead of modifying values within rules.

## Related issue(s)

Alternative to #75

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
