### PR TITLE
Configuration schema and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2026
 
+* 30 July 2026: Phylogenetic workflow configuration is now validated against a strict schema. The workflow will error if your configuration has extraneous entries that were previously ignored.
 * 30 July 2026: phylogenetic - Use `files.reference` as the root sequence for `augur ancestral` to support using builds as Nextclade datsets.
 * 24 July 2026: Removed config `files.colors` from phylogenetic workflow defaults. The value has been unused since the update on 14 January 2026.
 * 23 July 2026: In order to produce more relevant analyses for ongoing outbreaks, this workflow has shifted from producing only "N450" and "genome" builds to producing builds which specify their geographic resolution: "N450/global", "genome/global" and "genome/north-america". This extra versatility has required big changes to the config structure. **The following are breaking changes**:

--- a/phylogenetic/config.schema.yaml
+++ b/phylogenetic/config.schema.yaml
@@ -1,0 +1,146 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Measles Phylogenetic Workflow Configuration
+description: >-
+  This is the schema for the Nextstrain measles phylogenetic workflow's
+  configuration file.
+
+$defs:
+  per_build_map: &per_build_map
+    type: object
+    additionalProperties: false
+    propertyNames:
+      title: Build name
+      description: Build name (e.g. 'genome/global')
+
+  per_gene_map: &per_gene_map
+    type: object
+    additionalProperties: false
+    propertyNames:
+      title: Gene name
+      description: Gene name (e.g. 'genome' or 'N450')
+
+  input_item:
+    type: object
+    additionalProperties: false
+    required:
+      - name
+    anyOf:
+      - required: [metadata]
+      - required: [sequences]
+    properties:
+      name:
+        type: string
+      metadata:
+        type: string
+      sequences:
+        type: string
+
+  # An argument string passed directly to a command in the workflow. To be
+  # parsed/validated by the command at run time (e.g. argparse).
+  argument_string:
+    type: string
+
+type: object
+additionalProperties: false
+properties:
+  builds:
+    type: [string, array]
+    items:
+      type: string
+    minItems: 1
+  strain_id_field:
+    type: string
+  inputs:
+    type: array
+    items:
+      $ref: "#/$defs/input_item"
+  additional_inputs:
+    type: array
+    items:
+      $ref: "#/$defs/input_item"
+  files:
+    type: object
+    additionalProperties: false
+    properties:
+      reference:
+        type: string
+      reference_fasta:
+        type: string
+      auspice_config:
+        type: string
+      description:
+        type: string
+  nextclade:
+    <<: *per_gene_map
+    description: Map of gene name strings (e.g. 'genome' or 'N450') to argument strings.
+    patternProperties:
+      "^.*$":
+        $ref: "#/$defs/argument_string"
+  subsample: &subsample_config
+    <<: *per_build_map
+    description: >-
+      Subsampling configuration. When using --configfile, it is recommended to
+      use 'custom_subsample' instead to ignore default subsampling configuration.
+    patternProperties:
+      "^.*$":
+        $ref: "https://nextstrain.org/schemas/augur/subsample-config/v1"
+  custom_subsample:
+    <<: *subsample_config
+    description: >-
+      Custom subsampling configuration. When using --configfile, this is
+      recommended over 'subsample' to ignore default subsampling configuration.
+  refine:
+    <<: *per_build_map
+    description: Map of build name strings (e.g. 'genome/global') to argument strings.
+    patternProperties:
+      "^.*$":
+        $ref: "#/$defs/argument_string"
+  ancestral:
+    type: object
+    additionalProperties: false
+    properties:
+      inference:
+        type: string
+  traits:
+    <<: *per_build_map
+    patternProperties:
+      "^.*$":
+        oneOf:
+          - type: boolean
+          - type: object
+            additionalProperties: false
+            properties:
+              columns:
+                type: array
+                items:
+                  type: string
+              sampling_bias_correction:
+                type: number
+  tip_frequencies:
+    type: object
+    additionalProperties: false
+    properties:
+      min_date:
+        type: [string, number]
+      max_date:
+        type: [string, number]
+      narrow_bandwidth:
+        type: number
+      wide_bandwidth:
+        type: number
+  export:
+    <<: *per_build_map
+    patternProperties:
+      "^.*$":
+        type: object
+        additionalProperties: false
+        properties:
+          metadata_columns:
+            type: string
+          warning:
+            type: string
+  custom_rules:
+    type: array
+    description: Custom Snakemake rule files to include.
+    items:
+      type: string

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -6,6 +6,12 @@ OUTPUTS:
     results/run_config.yaml
     results/{build}/subsample_config.yaml
 """
+import jsonschema
+import sys
+import yaml
+from augur.validate import validate_json, ValidateError
+from pathlib import Path
+
 
 def get_gene(build: str) -> str:
     """Extract the gene from a multi-part build string (e.g. 'genome/global' -> 'genome')."""
@@ -13,10 +19,13 @@ def get_gene(build: str) -> str:
 
 
 def main():
+    dump_and_validate(
+        "results/run_config.yaml",
+        Path(workflow.basedir) / "config.schema.yaml"
+    )
     normalize_config()
-    validate_config()
+    validate_config_values()
     write_subsample_config()
-    write_config("results/run_config.yaml")
 
 
 def normalize_config():
@@ -25,51 +34,52 @@ def normalize_config():
         config['builds'] = [config['builds']]
 
 
-def validate_config():
+# TODO: move this to nextstrain/shared
+def dump_and_validate(dump_path, schema_path):
     """
-    Validate the config.
+    Write Snakemake's 'config' variable to a file, then validate it against the
+    schema. Do both in the same function so that the validation output can
+    easily reference the path of the dumped config for inspection.
+    """
+    global config
 
-    This could be improved with a schema definition file, but for now it serves
-    to provide useful error messages for common user errors and effects of
-    breaking changes.
+    write_config(dump_path)
+
+    with open(schema_path, "r") as f:
+        raw_schema = yaml.safe_load(f)
+
+    Validator = jsonschema.validators.validator_for(raw_schema)
+    validator = Validator(raw_schema)
+
+    try:
+        validate_json(config, validator, dump_path)
+    except ValidateError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        exit(1)
+
+
+def validate_config_values():
     """
+    Perform custom value checks that can't be handled by schema validation.
+    """
+    global config
+
     # Config keys whose value must be a dict keyed by build name, with one entry
     # for each build listed in config.builds. (Extra values are allowed so that
     # you can specify a custom subset of builds via --config or similar.)
-    per_build_keys = ["subsample", "refine", "traits", "export"]
-
-    builds = set(config["builds"])
-
-    for key in per_build_keys:
-        if key not in config:
-            raise InvalidConfigError(f"Config must define a 'config.{key}' section")
-
-        value = config[key]
-        if not isinstance(value, dict):
-            raise InvalidConfigError(
-                f"Config 'config.{key}' must be a dict keyed by build name, "
-                f"but it is a {type(value).__name__}"
-            )
-
-        missing_builds = builds - set(value)
-        if len(missing_builds):
+    for key in ["subsample", "refine", "traits", "export"]:
+        if missing_builds := set(config["builds"]) - set(config[key]):
             raise InvalidConfigError(
                 f"The keys of 'config.{key}' must contain all requested builds; "
                 f"you are currently missing ({', '.join(sorted(missing_builds))})"
             )
 
     # gene wildcard values must be present in the nextclade config entry
-    if not isinstance(config['nextclade'], dict):
-        raise InvalidConfigError(
-            f"Config 'config.nextclade' must be a dict but it is a {type(config['nextclade']).__name__}"
-        )
-    missing_gene_vals = set([get_gene(build) for build in config["builds"]]) - set(config['nextclade'].keys())
-    if len(missing_gene_vals):
+    if missing_gene_vals := set([get_gene(build) for build in config["builds"]]) - set(config['nextclade'].keys()):
         raise InvalidConfigError(
             f"The keys of 'config.nextclade' must contain all necessary 'gene' values; "
             f"you are currently missing ({', '.join(sorted(missing_gene_vals))})"
         )
-
 
 
 def write_subsample_config():


### PR DESCRIPTION
## Description of proposed changes

Adds a YAML schema file for the structure of the current 'config' variable and uses it for validation on the variable at the start of the workflow.

Note that this doesn't include user-facing docs – I haven't figured out how to generate docs out of this schema that are actually useful – but it's a start.

## Related issue(s)

https://github.com/nextstrain/public/issues/46

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog
- [x] Post-merge: [offline refs](https://github.com/nextstrain/measles/pull/88#discussion_r3668409391)
- [ ] Post-merge: potential follow-up c00248c1f42703dfc7e80330c8e57d079321742e

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
