### PR TITLE
Remove `custom_subsample` with custom config merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 
 ## 2025
+* TBD: The `custom_subsample` configuration section is no longer supported. Use `subsample` instead. [#89][]
 * 30 September 2025: The `'gene'` wildcard was renamed as `'build'`, and is now a config key rather than a declaration in the `phylogenetic` snakefile.
 * 29 September 2025: Restored support for `nextstrain run`, which was broken in the switch the augur subsample. [#73][]
 * 26 September 2025: Updated workflow compatibility declaration in `nextstrain-pathogen.yaml`.
@@ -34,6 +35,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 [#69]: https://github.com/nextstrain/measles/pull/69
 [#70]: https://github.com/nextstrain/measles/pull/70
 [#73]: https://github.com/nextstrain/measles/issues/73
+[#89]: https://github.com/nextstrain/measles/pull/89
 [nextstrain/shared]: https://github.com/nextstrain/shared
 
 ## 2024

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -9,13 +9,12 @@ OUTPUTS:
 # NOTE: The order is important. Filepaths must be resolved before config is
 # written, otherwise augur subsample will not work.
 
+config = load_config()
+
 resolve_filepaths([
     ("subsample", "*", "samples", "*", "include"),
     ("subsample", "*", "samples", "*", "exclude"),
     ("subsample", "*", "samples", "*", "group_by_weights"),
-    ("custom_subsample", "*", "samples", "*", "include"),
-    ("custom_subsample", "*", "samples", "*", "exclude"),
-    ("custom_subsample", "*", "samples", "*", "group_by_weights"),
 ])
 
 write_config("results/run_config.yaml")

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -46,7 +46,7 @@ rule filter:
     output:
         sequences = "results/genome/filtered.fasta"
     params:
-        config_section = ["custom_subsample" if config.get("custom_subsample") else "subsample", "genome"],
+        config_section = ["subsample", "genome"],
         strain_id = config["strain_id_field"]
     shell:
         """

--- a/phylogenetic/rules/prepare_sequences_N450.smk
+++ b/phylogenetic/rules/prepare_sequences_N450.smk
@@ -39,7 +39,7 @@ rule filter_N450:
     output:
         sequences = "results/N450/aligned.fasta"
     params:
-        config_section = ["custom_subsample" if config.get("custom_subsample") else "subsample", "N450"],
+        config_section = ["subsample", "N450"],
         strain_id = config["strain_id_field"]
     shell:
         """


### PR DESCRIPTION
> [!NOTE]
> Based on https://github.com/nextstrain/shared/pull/63

## Description of proposed changes

This PR has a working implementation of custom config merging at workflow startup time within Snakemake, a practical solution to remove the need for `custom_subsample`.

## Related issue(s)

- https://github.com/nextstrain/public/issues/28
- https://github.com/nextstrain/rsv/issues/106

## Checklist

- [x] Checks pass
- [x] Update changelog
- [ ] Pre-merge: drop first commit for https://github.com/nextstrain/shared/pull/63
- [ ] Pre-merge: update changelog to replace TBD

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
