### PR TITLE
allow phylo action regardless of cache result

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -112,7 +112,7 @@ jobs:
 
   phylogenetic:
     needs: [check-new-data]
-    if: ${{ needs.check-new-data.outputs.cache-hit != 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-new-data.outputs.cache-hit != 'true' }}
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master


### PR DESCRIPTION
When we've made changes to the (phylo) code, it's useful to be able to rebuild the trees even if there is no new data

[Action running](https://github.com/nextstrain/measles/actions/runs/21014993630)

<img width="391" height="552" alt="image" src="https://github.com/user-attachments/assets/fdd77889-3a7f-40ba-bfa7-22255a62f76d" />


