### PR TITLE
ci: Update subsampling config to match example data

### DIFF
--- a/phylogenetic/build-configs/ci/config.yaml
+++ b/phylogenetic/build-configs/ci/config.yaml
@@ -5,3 +5,19 @@
 # The paths should be relative to the phylogenetic directory.
 custom_rules:
   - build-configs/ci/copy_example_data.smk
+
+subsample:
+    genome:
+        samples:
+            early:
+                min_date: 1950
+                max_date: 2017
+            late:
+                min_date: 2017
+    N450:
+        samples:
+            early:
+                min_date: 1950
+                max_date: 2017
+            late:
+                min_date: 2017


### PR DESCRIPTION
## Description of proposed changes

If we subsample by the relative date values, then we'll inevitably run into filter errors at some point with the static example data.

This commit adds hardcoded dates for `min_date` and `max_date` that fit our current set of example data.

## Related issue(s)

Resolves https://github.com/nextstrain/measles/issues/99

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
