### PR TITLE
phylo: Support build specific params for refine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 
 ## 2026
+* 17 April 2026: phylogenetic - backwards compatible changes to support build specific refine params. [#122][]
+    - Build specific params can be defined as `refine.<build>.<param_name>`
+    - Previous refine params for all builds (`refine.<param_name>`) still work as expected
+    - Increase genome `clock_filter_iqd` to 8 to include more B3s
+    - Resets N450 `clock_filter_iqd` to 4 to continue to filter out outliers
 * 7 April 2026: phylogenetic - bump default `refine.clock_filter_iqd` to 6 to include
   more samples in build, i.e. to make sure B3 does not get dropped from genome builds. [#116][]
 * 6 March 2026: Fixed support for workflow configurations that use a subset of builds. [#113][]
@@ -43,6 +48,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 [#108]: https://github.com/nextstrain/measles/pull/108
 [#113]: https://github.com/nextstrain/measles/pull/113
 [#116]: https://github.com/nextstrain/measles/pull/116
+[#122]: https://github.com/nextstrain/measles/pull/122
 [530da56]: https://github.com/nextstrain/measles/commit/530da568d8014c08e73f31065a8fa96e5c2d2f20
 [1cf1299...0313508]: https://github.com/nextstrain/measles/compare/1cf1299e1658140d9317fc9063f1e06ef04a6ee1...03135085aed310f1cb0d3ecb2dca342e6ec8f51d
 [Pathoplexus]: https://pathoplexus.org

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -59,11 +59,11 @@ refine:
     genome:
         coalescent: "opt"
         date_inference: "marginal"
-        clock_filter_iqd: 6
+        clock_filter_iqd: 8
     N450:
         coalescent: "opt"
         date_inference: "marginal"
-        clock_filter_iqd: 6
+        clock_filter_iqd: 4
 ancestral:
     inference: "joint"
 # trait reconstruction applies only to the "genome" build

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -56,9 +56,14 @@ subsample:
                 include: include_strains_N450.txt
                 exclude: dropped_strains.txt
 refine:
-    coalescent: "opt"
-    date_inference: "marginal"
-    clock_filter_iqd: 6
+    genome:
+        coalescent: "opt"
+        date_inference: "marginal"
+        clock_filter_iqd: 6
+    N450:
+        coalescent: "opt"
+        date_inference: "marginal"
+        clock_filter_iqd: 6
 ancestral:
     inference: "joint"
 # trait reconstruction applies only to the "genome" build

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -23,6 +23,36 @@ rule tree:
             --output {output.tree}
         """
 
+def _get_refine_param(wildcards, param_name):
+    """
+    Get refine param in a backwards compatible manner. Config can define:
+    1. params for all builds (old)
+
+        refine:
+            <param_name>: ...
+
+    2. build specific params (new)
+
+        refine:
+            <build>:
+                <param_name>: ...
+    """
+    # Check for the old format first so that users don't need to update their
+    # configs unless they want to
+    if (all_build_param := config["refine"].get(param_name)) is not None:
+        return all_build_param
+
+    # Check build key before the inner param_name to support build nullification, e.g.
+    #     refine:
+    #         N450: ~
+    if (build_params := config["refine"].get(wildcards.build)) is not None:
+        if (param := build_params.get(param_name)) is not None:
+            return param
+
+    raise Exception(f"Could not parse config param {param_name!r} for refine rule.",
+                    f"It should be defined as `refine.{param_name}` or `refine.{wildcards.build}.{param_name}`")
+
+
 rule refine:
     """
     Refining tree
@@ -39,9 +69,9 @@ rule refine:
         tree = "results/{build}/tree.nwk",
         node_data = "results/{build}/branch_lengths.json"
     params:
-        coalescent = config["refine"]["coalescent"],
-        date_inference = config["refine"]["date_inference"],
-        clock_filter_iqd = config["refine"]["clock_filter_iqd"],
+        coalescent = lambda w: _get_refine_param(w, "coalescent"),
+        date_inference = lambda w: _get_refine_param(w, "date_inference"),
+        clock_filter_iqd = lambda w: _get_refine_param(w, "clock_filter_iqd"),
         strain_id = config["strain_id_field"]
     log:
         "logs/refine_{build}.txt",

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -23,7 +23,7 @@ rule tree:
             --output {output.tree}
         """
 
-def _get_refine_param(wildcards, param_name):
+def _get_refine_param(param_name):
     """
     Get refine param in a backwards compatible manner. Config can define:
     1. params for all builds (old)
@@ -37,20 +37,22 @@ def _get_refine_param(wildcards, param_name):
             <build>:
                 <param_name>: ...
     """
-    # Check for the old format first so that users don't need to update their
-    # configs unless they want to
-    if (all_build_param := config["refine"].get(param_name)) is not None:
-        return all_build_param
+    def _inner(wildcards):
+        # Check for the old format first so that users don't need to update their
+        # configs unless they want to
+        if (all_build_param := config["refine"].get(param_name)) is not None:
+            return all_build_param
 
-    # Check build key before the inner param_name to support build nullification, e.g.
-    #     refine:
-    #         N450: ~
-    if (build_params := config["refine"].get(wildcards.build)) is not None:
-        if (param := build_params.get(param_name)) is not None:
-            return param
+        # Check build key before the inner param_name to support build nullification, e.g.
+        #     refine:
+        #         N450: ~
+        if (build_params := config["refine"].get(wildcards.build)) is not None:
+            if (param := build_params.get(param_name)) is not None:
+                return param
 
-    raise Exception(f"Could not parse config param {param_name!r} for refine rule.",
-                    f"It should be defined as `refine.{param_name}` or `refine.{wildcards.build}.{param_name}`")
+        raise Exception(f"Could not parse config param {param_name!r} for refine rule.",
+                        f"It should be defined as `refine.{param_name}` or `refine.{wildcards.build}.{param_name}`")
+    return _inner
 
 
 rule refine:
@@ -69,9 +71,9 @@ rule refine:
         tree = "results/{build}/tree.nwk",
         node_data = "results/{build}/branch_lengths.json"
     params:
-        coalescent = lambda w: _get_refine_param(w, "coalescent"),
-        date_inference = lambda w: _get_refine_param(w, "date_inference"),
-        clock_filter_iqd = lambda w: _get_refine_param(w, "clock_filter_iqd"),
+        coalescent = _get_refine_param("coalescent"),
+        date_inference = _get_refine_param("date_inference"),
+        clock_filter_iqd = _get_refine_param("clock_filter_iqd"),
         strain_id = config["strain_id_field"]
     log:
         "logs/refine_{build}.txt",

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -43,12 +43,8 @@ def _get_refine_param(param_name):
         if (all_build_param := config["refine"].get(param_name)) is not None:
             return all_build_param
 
-        # Check build key before the inner param_name to support build nullification, e.g.
-        #     refine:
-        #         N450: ~
-        if (build_params := config["refine"].get(wildcards.build)) is not None:
-            if (param := build_params.get(param_name)) is not None:
-                return param
+        if (build_param := config["refine"].get(wildcards.build, {}).get(param_name)) is not None:
+            return build_param
 
         raise Exception(f"Could not parse config param {param_name!r} for refine rule.",
                         f"It should be defined as `refine.{param_name}` or `refine.{wildcards.build}.{param_name}`")


### PR DESCRIPTION
## Description of proposed changes

This is a backwards compatible change where configs can define either all build params under `refine.<param_name>` or define build specificparams as `refine.<build>.<param_name>`.

Includes changes to the `clock_filter_iqd` param
1. Increase to 8 for genome build to include more B3 genomes
2. Decrease to 4 for N450 build to filter outliers - this is just resetting the clock filter to what it was before changes in
<https://github.com/nextstrain/measles/pull/116>

## Related issue(s)

Resolves https://github.com/nextstrain/measles/issues/118

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
