### PR TITLE
Make divergence units configurable in config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 
 ## 2026
+* 10 July 2026: phylogenetic - non-breaking changes to the `refine` params. Divergence units are now exposed
+  to the default `config.yaml` so that they are configurable as `mutations` versus `mutations-per-site`.
 * 17 April 2026: phylogenetic - backwards compatible changes to support build specific refine params. [#122][]
     - Build specific params can be defined as `refine.<build>.<param_name>`
     - Previous refine params for all builds (`refine.<param_name>`) still work as expected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 
 ## 2026
-* 10 July 2026: phylogenetic - non-breaking changes to the `refine` params. Divergence units are now exposed
-  to the default `config.yaml` so that they are configurable as `mutations` versus `mutations-per-site`.
+* 10 July 2026: [Divergence units](https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/refine.html) can now be configured using `refine.<build>.divergence_units`.
 * 17 April 2026: phylogenetic - backwards compatible changes to support build specific refine params. [#122][]
     - Build specific params can be defined as `refine.<build>.<param_name>`
     - Previous refine params for all builds (`refine.<param_name>`) still work as expected

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -60,10 +60,12 @@ refine:
         coalescent: "opt"
         date_inference: "marginal"
         clock_filter_iqd: 8
+        divergence_units: "mutations-per-site"
     N450:
         coalescent: "opt"
         date_inference: "marginal"
         clock_filter_iqd: 4
+        divergence_units: "mutations-per-site"
 ancestral:
     inference: "joint"
 # trait reconstruction applies only to the "genome" build

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -70,7 +70,8 @@ rule refine:
         coalescent = _get_refine_param("coalescent"),
         date_inference = _get_refine_param("date_inference"),
         clock_filter_iqd = _get_refine_param("clock_filter_iqd"),
-        strain_id = config["strain_id_field"]
+        strain_id = config["strain_id_field"],
+        divergence_units = _get_refine_param("divergence_units")
     log:
         "logs/refine_{build}.txt",
     benchmark:
@@ -91,5 +92,6 @@ rule refine:
             --date-confidence \
             --date-inference {params.date_inference} \
             --clock-filter-iqd {params.clock_filter_iqd} \
-            --stochastic-resolve
+            --stochastic-resolve \
+            --divergence-units {params.divergence_units}
         """


### PR DESCRIPTION
## Added option for alternative divergence units for augur refine (`--divergence-units`) to be specified via `config.yaml`.

This keeps the default divergence units for `augur refine` as `mutations-per-site` but routes this option to the config and makes it explicit. This should allow for the divergence/x-axis units to be visualized in terms of absolute number of mutations easily in a custom config.

Tested with both 'build=['genome', 'N450']' as well as 'build=['genome']'