### PR TITLE
ci: Add test for `nextstrain run` with outbreak example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,3 +10,31 @@ on:
 jobs:
   ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+
+  nextstrain_run:
+    runs-on: ubuntu-latest
+    env:
+      EXAMPLE_DIR: phylogenetic/custom-analyses/north-america-outbreak-example/
+      ANALYSIS_DIR: analysis-directory/
+    steps:
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: Setup pathogen
+        run: nextstrain setup measles@${{ github.sha }}
+
+      - name: Checkout analysis directory
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          # Disable cone mode to ensure that we only include files _within_ EXAMPLE_DIR
+          sparse-checkout-cone-mode: false
+          sparse-checkout: ${{ env.EXAMPLE_DIR }}
+          path: ${{ env.ANALYSIS_DIR }}
+
+      - name: Setup analysis directory
+        run: |
+          mv ${{ env.ANALYSIS_DIR }}${{ env.EXAMPLE_DIR }}* ${{ env.ANALYSIS_DIR }}
+
+        # TODO: run other workflows
+      - name: Run phylo example
+        run: nextstrain run measles@${{ github.sha }} phylogenetic ${{ env.ANALYSIS_DIR }}


### PR DESCRIPTION
## Description of proposed changes

Add single test for `nextstrain run` with the north-america-outbreak-example that is used in the tutorial. 

In the future, we can consider adding tests for other workflows and move these tests to a generalized reusable workflow in nextstrain/.github.

## Related issue(s)

Follow up to <https://github.com/nextstrain/measles/pull/124#discussion_r3640652789>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~ internal change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
