### PR TITLE
phylo: Add `--root-sequence` to ancestral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2026
 
+* 30 July 2026: phylogenetic - Use `files.reference` as the root sequence for `augur ancestral` to support using builds as Nextclade datsets.
 * 24 July 2026: Removed config `files.colors` from phylogenetic workflow defaults. The value has been unused since the update on 14 January 2026.
 * 23 July 2026: In order to produce more relevant analyses for ongoing outbreaks, this workflow has shifted from producing only "N450" and "genome" builds to producing builds which specify their geographic resolution: "N450/global", "genome/global" and "genome/north-america". This extra versatility has required big changes to the config structure. **The following are breaking changes**:
   * The `refine` section now expects a single argument string for each `refine.<build>` in config. This provides a consistent and flexible pattern for passing **non-file** arguments to Augur.

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -9,7 +9,8 @@ rule ancestral:
     """Reconstructing ancestral sequences and mutations"""
     input:
         tree = "results/{build}/tree.nwk",
-        alignment = "results/{build}/aligned.fasta"
+        alignment = "results/{build}/aligned.fasta",
+        root = lambda w: resolve_config_path(config["files"]["reference"])({'gene': get_gene(w.build)}),
     output:
         node_data = "results/{build}/nt_muts.json"
     params:
@@ -26,7 +27,8 @@ rule ancestral:
             --tree {input.tree} \
             --alignment {input.alignment} \
             --output-node-data {output.node_data} \
-            --inference {params.inference}
+            --inference {params.inference} \
+            --root-sequence {input.root}
         """
 
 rule translate:


### PR DESCRIPTION
## Description of proposed changes

Without the explicit root sequence, the tree uses the inferred ancestral sequence as the root, which can lead to gaps that causes an error in Nextclade.

## Related issue(s)

Resolves https://github.com/nextstrain/measles/issues/139

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
