### PR TITLE
Validate schema locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2026
 
+* 6 August 2026: Phylogenetic workflow configuration schema validation no longer requires an internet connection.
 * 5 August 2026: Phylogenetic workflow configuration schema is only validated when not using `custom_rules`.
 * 30 July 2026: Phylogenetic workflow configuration is now validated against a strict schema. The workflow will error if your configuration has extraneous entries that were previously ignored.
 * 30 July 2026: phylogenetic - Use `files.reference` as the root sequence for `augur ancestral` to support using builds as Nextclade datsets.

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -6,10 +6,9 @@ OUTPUTS:
     results/run_config.yaml
     results/{build}/subsample_config.yaml
 """
-import jsonschema
 import sys
 import yaml
-from augur.validate import validate_json, ValidateError
+from augur.validate import load_json_schema_locally, validate_json, ValidateError
 from pathlib import Path
 
 
@@ -49,13 +48,9 @@ def dump_and_validate(dump_path, schema_path):
         print("WARNING: Skipping config schema validation because custom rules are defined.", file=sys.stderr)
         return
 
-    with open(schema_path, "r") as f:
-        raw_schema = yaml.safe_load(f)
-
-    Validator = jsonschema.validators.validator_for(raw_schema)
-    validator = Validator(raw_schema)
 
     try:
+        validator = load_json_schema_locally(schema_path)
         validate_json(config, validator, dump_path)
     except ValidateError as e:
         print(f"ERROR: {e}", file=sys.stderr)


### PR DESCRIPTION
## Description of proposed changes

Previously, the URL reference to the subsample config schema required an internet connection. `load_json_schema_locally()` uses the schema file available in the local Augur installation.

Not only does this enable offline use, but it also ensures the subsample schema reflects the current Augur version (URL may serve schema for a newer version).

## Related issue(s)

Follow-up to https://github.com/nextstrain/measles/pull/88#discussion_r3668409391

## Checklist

- [x] Tested locally without internet connection
- [ ] Merge+release https://github.com/nextstrain/augur/pull/2034
- [ ] Checks pass
- [x] Update changelog
