### PR TITLE
phylo/config schema: Add `deploy_url`

### DIFF
--- a/phylogenetic/config.schema.yaml
+++ b/phylogenetic/config.schema.yaml
@@ -144,3 +144,9 @@ properties:
     description: Custom Snakemake rule files to include.
     items:
       type: string
+  # This is only used a custom rule in `nextstrain-automation`.
+  # We can revisit this when we come to a consensus on how to handle custom
+  # params in <https://github.com/nextstrain/measles/issues/142>
+  deploy_url:
+    type: string
+    description: URL for deploying builds for nextstrain-automation


### PR DESCRIPTION
## Description of proposed changes

This is used in a custom rule for `nextstrain-automation`. We do not have a great way to handle extended schemas yet, so adding to the core config schema for now.

## Related issue(s)

We can revisit when we've come to a consensus in
<https://github.com/nextstrain/measles/issues/142>.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
