### PR TITLE
Skip schema validation when using custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2026
 
+* 5 August 2026: Phylogenetic workflow configuration schema is only validated when not using `custom_rules`.
 * 30 July 2026: Phylogenetic workflow configuration is now validated against a strict schema. The workflow will error if your configuration has extraneous entries that were previously ignored.
 * 30 July 2026: phylogenetic - Use `files.reference` as the root sequence for `augur ancestral` to support using builds as Nextclade datsets.
 * 24 July 2026: Removed config `files.colors` from phylogenetic workflow defaults. The value has been unused since the update on 14 January 2026.

--- a/phylogenetic/config.schema.yaml
+++ b/phylogenetic/config.schema.yaml
@@ -141,12 +141,6 @@ properties:
             type: string
   custom_rules:
     type: array
-    description: Custom Snakemake rule files to include.
+    description: Custom Snakemake rule files to include. If used, this will disable config schema validation.
     items:
       type: string
-  # This is only used a custom rule in `nextstrain-automation`.
-  # We can revisit this when we come to a consensus on how to handle custom
-  # params in <https://github.com/nextstrain/measles/issues/142>
-  deploy_url:
-    type: string
-    description: URL for deploying builds for nextstrain-automation

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -45,6 +45,10 @@ def dump_and_validate(dump_path, schema_path):
 
     write_config(dump_path)
 
+    if "custom_rules" in config:
+        print("WARNING: Skipping config schema validation because custom rules are defined.", file=sys.stderr)
+        return
+
     with open(schema_path, "r") as f:
         raw_schema = yaml.safe_load(f)
 


### PR DESCRIPTION
## Description of proposed changes

This lets the schema reflect the stock workflow without custom rules from nextstrain-automation, where validation is now skipped.

We could support extending the schema, but that would complicate things as a new feature.

## Related issue(s)

Alternative to #143 proposed in https://github.com/nextstrain/measles/issues/142#issuecomment-5184978981

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog
- [x] Replace TBD in changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
